### PR TITLE
Allow HTTPS and NTP egress from bastion server

### DIFF
--- a/vpc.cfn.yml
+++ b/vpc.cfn.yml
@@ -235,6 +235,14 @@ Resources:
         IpProtocol: tcp
         ToPort: 80
         FromPort: 80
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        ToPort: 443
+        FromPort: 443
+      - CidrIp: 0.0.0.0/0
+        IpProtocol: udp
+        ToPort: 123
+        FromPort: 123
       Tags:
       - Key: Name
         Value: !Sub "${AWS::StackName}-BastionSecurityGroup"


### PR DESCRIPTION
This PR changes the BastionSecurityGroup to allow egress to HTTPS and NTP. These two changes are related to the upcoming multi-factor auth feature.