### PR TITLE
Updating Node Version in  StackMap reference.

### DIFF
--- a/app.cfn.yml
+++ b/app.cfn.yml
@@ -121,7 +121,7 @@ Mappings:
   # Maps stack type parameter to solution stack name string
   StackMap:
     node:
-      stackName: 64bit Amazon Linux 2017.03 v4.2.2 running Node.js
+      stackName: 64bit Amazon Linux 2017.03 v4.3.0 running Node.js
     rails:
       stackName: 64bit Amazon Linux 2017.03 v2.4.4 running Ruby 2.3 (Puma)
     spring:


### PR DESCRIPTION
The node version for the EBS stackName mappings from  the outdated: "64bit Amazon Linux 2017.03 v4.2.2" running Node.js  to: "64bit Amazon Linux 2017.03 v4.3.0 running Node.js" .  I tried running this with the sample cloudformation node app and received an error.  Using the updated node version  4.30 image resolves the error.