### PR TITLE
Support for Billing alerts

### DIFF
--- a/templates/bastion.cfn.yml
+++ b/templates/bastion.cfn.yml
@@ -265,7 +265,7 @@ Resources:
       LogGroupName: !Ref BastionSecureLogGroup
       LogStreamName: log
 
-  # When a user tries to SSH with invalid username the next line is logged in the SSH log file
+  # When a user tries to SSH with invalid username the activity is logged in the SSH log file
   SshInvalidUserMetricFilter:
       Type: AWS::Logs::MetricFilter
       Properties:
@@ -287,6 +287,7 @@ Resources:
         EvaluationPeriods: 1
         Threshold: 3
         ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
 
   # When a user uses a bad private key pair or username
   SshClosedConnectionMetricFilter:
@@ -302,14 +303,15 @@ Resources:
   SshClosedConnectionAlarm:
       Type: AWS::CloudWatch::Alarm
       Properties:
-        AlarmDescription: SSH conneections closed due to invalid SSH key or username is greater than 10 in 5 minutes
+        AlarmDescription: SSH connections closed due to invalid SSH key or username is greater than 5 in 5 minutes
         MetricName: sshClosedConnection
         Namespace: SSH
         Statistic: Sum
         Period: 300
         EvaluationPeriods: 1
-        Threshold: 15
+        Threshold: 5
         ComparisonOperator: GreaterThanThreshold
+        TreatMissingData: notBreaching
 
 Outputs:
 

--- a/templates/billing-alerts.cfn.yml
+++ b/templates/billing-alerts.cfn.yml
@@ -1,0 +1,55 @@
+---
+AWSTemplateFormatVersion: 2010-09-09
+
+Parameters:
+
+  AlarmThreshold:
+    Description: Set a threshold for the alarm to go off if the estimated charge is exceeded. 
+    Type: Number
+    MinValue: 1
+    MaxValue: 10000000
+
+  Email:
+    Description: Email address to notify if the threshold is breached. You should get a confirmation email from SNS once the resources are created.
+    Type: String
+    AllowedPattern: ^[_A-Za-z0-9-\+]+(\.[_A-Za-z0-9-]+)*@[A-Za-z0-9-]+(\.[A-Za-z0-9]+)*(\.[A-Za-z]{2,})$
+
+Resources:
+
+  BillingAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmDescription: !Sub Alarm if AWS spending is over $${AlarmThreshold}
+      Namespace: AWS/Billing
+      MetricName: EstimatedCharges
+      Dimensions:
+      - Name: Currency
+        Value: USD
+      Statistic: Maximum
+      Period: 21600
+      EvaluationPeriods: 1
+      Threshold: !Ref AlarmThreshold
+      ComparisonOperator: GreaterThanThreshold
+      AlarmActions:
+      - !Ref BillingAlarmTopic
+
+  BillingAlarmTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+      - Endpoint: !Ref Email
+        Protocol: email
+
+Outputs:
+
+  BillingAlarmTopicArn:
+    Description: Billing Alarm Topic ARN
+    Value: !Ref BillingAlarmTopic
+    Export:
+      Name: !Sub ${AWS::StackName}-BillingAlarmTopicArn
+
+  BillingAlarmTopicName:
+    Description: Billing Alarm Topic Name
+    Value: !GetAtt BillingAlarmTopic.TopicName
+    Export:
+        Name: !Sub ${AWS::StackName}-BillingAlarmTopicName


### PR DESCRIPTION
This PR adds support for setting billing alerts and a few changes in the Bastion host template

The following features are added in the billing alerts template:

- Creates an alarm for estimated charges metric
- Creates an SNS topic for receiving notifications if the charges threshold is breached
- Subscribes an email address to the topic

The following changes are added in the Bastion host template

- Changed SSH closed connection alarm threshold from 15 to 5
- Added a parameter to ignore the insufficient/missing data in SSH

