### PR TITLE
Add db alarms

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 .project
 .settings/
 
+# Python
+*.pyc
+
 # Intellij
 .idea/
 *.iml

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ This repo contains a collection of AWS [CloudFormation](https://docs.aws.amazon.
 - An [Amazon Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_Aurora.html) DB cluster
 - [Billing alerts](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html) for your account
 
-The VPC template is a requirement for the others. You can either run the templates/vpc.cfn.yml template by itself prior to using the others, or run any one of the vpc-*.cfn.yml wrapper templates at the top level of this repo to create sets of resources. For example, vpc-bastion-fargate-rds.cfn.yml will create a single stack containing a vpc, bastion host, fargate cluster, and database.
+The VPC template is a requirement for the others. You can either run the templates/vpc.cfn.yml template by itself prior to using the others, or run any one of the vpc-\*.cfn.yml wrapper templates at the top level of this repo to create sets of resources. For example, vpc-bastion-fargate-rds.cfn.yml will create a single stack containing a vpc, bastion host, fargate cluster, and database.
 
 
 ## Prerequisites
@@ -229,64 +229,64 @@ CloudFormation | Region Name | Region | VPC | Bastion | DB | Fargate | Elastic B
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-southeast-2-vpc-bastion] | Asia Pacific (Sydney) | ap-southeast-2 | ✅  | ✅ |||
 [<img src="https://s3.amazonaws.com/cloudformation-examples/cloudformation-launch-stack.png" width="150"> ][ap-southeast-2-vpc-bastion-eb-rds] | Asia Pacific (Sydney) | ap-southeast-2 | ✅  | ✅  | ✅  || ✅   |
 
-[us-east-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[us-east-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[us-east-1-vpc-bastion-fargate]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-fargate.cfn.yml
-[us-east-1-vpc-bastion-fargate-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-fargate-rds.cfn.yml
-[us-east-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[us-east-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[us-east-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[us-east-1-vpc-bastion-fargate]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-fargate.cfn.yml
+[us-east-1-vpc-bastion-fargate-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-fargate-rds.cfn.yml
+[us-east-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[us-east-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[us-east-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[us-east-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[us-east-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[us-east-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[us-east-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-east-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[us-west-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[us-west-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[us-west-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[us-west-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[us-west-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[us-west-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[us-west-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[us-west-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[us-west-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[us-west-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[us-west-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[us-west-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=us-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[sa-east-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[sa-east-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[sa-east-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[sa-east-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[sa-east-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[sa-east-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=sa-east-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[eu-west-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[eu-west-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[eu-west-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[eu-west-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[eu-west-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[eu-west-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[eu-west-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[eu-west-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[eu-west-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[eu-west-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[eu-west-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[eu-west-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[eu-west-3-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[eu-west-3-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[eu-west-3-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[eu-west-3-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[eu-west-3-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[eu-west-3-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-west-3#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[eu-central-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[eu-central-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[eu-central-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[eu-central-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[eu-central-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[eu-central-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=eu-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[ap-south-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[ap-south-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[ap-south-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[ap-south-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[ap-south-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[ap-south-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-south-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[ap-northeast-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[ap-northeast-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[ap-northeast-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[ap-northeast-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[ap-northeast-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[ap-northeast-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[ap-northeast-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[ap-northeast-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[ap-northeast-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[ap-northeast-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[ap-northeast-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[ap-northeast-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-northeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[ap-southeast-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[ap-southeast-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[ap-southeast-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[ap-southeast-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[ap-southeast-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[ap-southeast-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[ap-southeast-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[ap-southeast-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[ap-southeast-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[ap-southeast-2-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[ap-southeast-2-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[ap-southeast-2-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ap-southeast-2#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml
 
-[ca-central-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml
-[ca-central-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml
-[ca-central-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml
+[ca-central-1-vpc]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc.cfn.yml
+[ca-central-1-vpc-bastion]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion.cfn.yml
+[ca-central-1-vpc-bastion-eb-rds]: https://console.aws.amazon.com/cloudformation/home?region=ca-central-1#/stacks/create/review?templateURL=https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/vpc-bastion-eb-rds.cfn.yml

--- a/bin/deploy.sh
+++ b/bin/deploy.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #
-# Usage: ./bin/deploy.sh awslabs-startup-kit-templates-deploy-v1 startup
+# Usage: ./bin/deploy.sh awslabs-startup-kit-templates-deploy-v2 startup
 #
 # The first argument is the bucket and the second is the aws cli profile
 #

--- a/bin/test.py
+++ b/bin/test.py
@@ -6,19 +6,15 @@ from botocore.client import Config
 
 TEST_APP_BUCKET_PREFIX='awslabs-startup-kit-templates-test-eb-v1-tmp-'
 TEST_APP_SOURCE_BUCKET='awslabs-startup-kit-templates-test-eb-v1'
-TEST_PYTHON_APP_KEY='eb-python-flask.zip'
-STACK_BUCKET='awslabs-startup-kit-templates-deploy-v1'
-EB_TEMPLATE_URL='https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion-eb-rds.cfn.yml'
-VPC_TEMPLATE_URL='https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc.cfn.yml'
-VPC_BASTION_TEMPLATE_URL='https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v1/vpc-bastion.cfn.yml'
-KEY_PAIR_PREFIX='sktemplates-test-'
 
-# TODO Add support for Fargate test in supported regions
-# TODO Delete the RDS snapshots and any other resources
-# TODO ssh into bastion host to validate
-# TODO Make http requests to endpoints to validate
-# TODO Connect to database through bastion to validate
-# TODO Store key pair temporarily and then cleanup
+TEST_PYTHON_APP_KEY='eb-python-flask.zip'
+
+TEMPLATE_URL_PREFX='https://s3.amazonaws.com/awslabs-startup-kit-templates-deploy-v2/'
+EB_TEMPLATE_URL='{}vpc-bastion-eb-rds.cfn.yml'.format(TEMPLATE_URL_PREFX)
+VPC_TEMPLATE_URL='{}vpc.cfn.yml'.format(TEMPLATE_URL_PREFX)
+VPC_BASTION_TEMPLATE_URL='{}vpc-bastion.cfn.yml'.format(TEMPLATE_URL_PREFX)
+
+KEY_PAIR_PREFIX='sktemplates-test-'
 
 def get_regions(client):
     """ Load the region codes
@@ -33,6 +29,11 @@ def get_availability_zones(client, region):
     """ Load the first two AZs for a region
     """
     azs = client.describe_availability_zones()['AvailabilityZones']
+
+    if len(azs) < 2:
+        print 'Region without two AZs (skipping): {}'.format(region)
+        return None
+
     return [ azs[0]['ZoneName'], azs[1]['ZoneName'] ]
 
 def create_key_pair(client, name):
@@ -44,7 +45,8 @@ def create_key_pair(client, name):
 def store_key_locally(name, private_key):
     """ Store the key in your ~/.ssh directory
     """
-    file_name = expanduser("~") + '/.ssh/' + name
+    file_name = '{}/.ssh/{}'.format(expanduser("~"), name)
+
     file = open(file_name, 'w')
     file.write(private_key)
     file.close()
@@ -65,10 +67,10 @@ def has_bucket(client, name):
     """ If the S3 bucket exists, then true is returned
     """
     try:
-        client.get_bucket_location(Bucket=name)
+        client.head_bucket(Bucket=name)
         return True
     except botocore.exceptions.ClientError as ce:
-        if ce.response['Error']['Code'] == 'NoSuchBucket':
+        if ce.response['Error']['Code'] == '404':
             return False
         raise ce
 
@@ -84,7 +86,7 @@ def create_bucket(client, name, region):
 def update_sample_app(client, app_bucket_name, source_bucket_name, app_key):
     """ Copy a sample app from the central bucket to the region where the stack is being created
     """
-    print 'Update sample app: ' + app_key
+    print 'Update sample app: {}'.format(app_key)
     copy_source = { 'Bucket': source_bucket_name, 'Key': app_key }
     client.copy(copy_source, app_bucket_name, app_key)
     client.put_object_acl(ACL='public-read', Bucket=app_bucket_name, Key=app_key)
@@ -127,10 +129,10 @@ def create_stack(client, stack_name, template_url, parameters):
     )
     return response['StackId']
 
-def create_eb_stack(client, stack_name, azs, environment, ssh_key, app_bucket, app_key, stack_type, db_engine):
+def create_eb_stack(client, stack_name, azs, environment, ssh_key, app_bucket, app_key, stack_type, db_engine, alarms, enhanced_alarms):
     """ Create the elastic beanstalk stack and return the stack id
     """
-    parameters=[
+    parameters = [
         { 'ParameterKey': 'EnvironmentName', 'ParameterValue': environment },
         { 'ParameterKey': 'AvailabilityZone1', 'ParameterValue': azs[0] },
         { 'ParameterKey': 'AvailabilityZone2', 'ParameterValue': azs[1] },
@@ -143,12 +145,19 @@ def create_eb_stack(client, stack_name, azs, environment, ssh_key, app_bucket, a
         { 'ParameterKey': 'DatabasePassword', 'ParameterValue': 'startupadmin6' },
         { 'ParameterKey': 'DatabaseEngine', 'ParameterValue': db_engine },
     ]
+
+    if alarms:
+        parameters.append({ 'ParameterKey': 'DatabaseEnableAlarms', 'ParameterValue': 'true' })
+        if enhanced_alarms:
+            parameters.append({ 'ParameterKey': 'DatabaseAlarmEvaluationPeriodSeconds', 'ParameterValue': '60' })
+            parameters.append({ 'ParameterKey': 'DatabaseEnhancedMonitoring', 'ParameterValue': 'true' })
+
     return create_stack(client, stack_name, EB_TEMPLATE_URL, parameters)
 
 def create_vpc_stack(client, stack_name, azs, environment):
     """ Create the elastic beanstalk stack and return the stack id
     """
-    parameters=[
+    parameters = [
         { 'ParameterKey': 'EnvironmentName', 'ParameterValue': environment },
         { 'ParameterKey': 'AvailabilityZone1', 'ParameterValue': azs[0] },
         { 'ParameterKey': 'AvailabilityZone2', 'ParameterValue': azs[1] },
@@ -158,7 +167,7 @@ def create_vpc_stack(client, stack_name, azs, environment):
 def create_vpc_bastion_stack(client, stack_name, azs, environment, ssh_key):
     """ Create the elastic beanstalk stack and return the stack id
     """
-    parameters=[
+    parameters = [
         { 'ParameterKey': 'EnvironmentName', 'ParameterValue': environment },
         { 'ParameterKey': 'AvailabilityZone1', 'ParameterValue': azs[0] },
         { 'ParameterKey': 'AvailabilityZone2', 'ParameterValue': azs[1] },
@@ -169,7 +178,7 @@ def create_vpc_bastion_stack(client, stack_name, azs, environment, ssh_key):
 def wait_for_stacks(stacks, create):
 
     action = 'create' if create else 'delete'
-    print 'Waiting for stacks to ' + action
+    print 'Waiting for stacks to {}'.format(action)
 
     while True:
         all_done = True
@@ -178,13 +187,13 @@ def wait_for_stacks(stacks, create):
                 if create:
                     if not is_stack(stack['client'], stack_id, 'CREATE_IN_PROGRESS'):
                         if has_stack_create_error(stack['client'], stack_id):
-                            print 'Stack failed to create - stack id: ' + stack_id + ' - region: ' + stack['region']
+                            print 'Stack failed to create stack id: {} - region: {}'.format(stack_id, stack['region'])
                     else:
                         all_done = False
                 else:
                     if not is_stack(stack['client'], stack_id, 'DELETE_IN_PROGRESS'):
                         if has_stack_delete_error(stack['client'], stack_id):
-                            print 'Stack failed to delete - stack id: ' + stack_id + ' - region: ' + stack['region']
+                            print 'Stack failed to delete stack id: {} - region: {}'.format(stack_id, stack['region'])
                     else:
                         all_done = False
 
@@ -197,18 +206,18 @@ def ensure_foundation(session, config):
     """
     for region in get_regions(session.client('ec2', region_name='us-east-1', config=config)):
 
-        print 'Ensure key pair in region: ' + region
+        print 'Ensure key pair in region: {}'.format(region)
 
         ec2_client = session.client('ec2', region_name=region, config=config)
-        key_name = KEY_PAIR_PREFIX + region
+        key_name = '{}{}'.format(KEY_PAIR_PREFIX, region)
         if not has_key_pair(ec2_client, key_name):
             store_key_locally(key_name, create_key_pair(ec2_client, key_name))
 
         s3_client = session.client('s3', region_name=region, config=config)
 
-        print 'Ensure S3 app bucket in region: ' + region
+        print 'Ensure S3 app bucket in region: {}'.format(region)
 
-        app_bucket_name = TEST_APP_BUCKET_PREFIX + region
+        app_bucket_name = '{}{}'.format(TEST_APP_BUCKET_PREFIX, region)
         if not has_bucket(s3_client, app_bucket_name):
             create_bucket(s3_client, app_bucket_name, region)
 
@@ -223,6 +232,10 @@ def test_stack(session, config, stack_type):
 
         azs = get_availability_zones(session.client('ec2', region_name=region, config=config), region)
 
+        # Single AZ regions are not supported e.g., ap-northeast-3
+        if azs is None:
+            continue
+
         stack = {}
         stacks.append(stack)
         cfn_client =  session.client('cloudformation', region_name=region, config=config)
@@ -232,20 +245,28 @@ def test_stack(session, config, stack_type):
         stack_ids = []
         stack['stack_ids'] = stack_ids
 
-        key_name = KEY_PAIR_PREFIX + region
-        app_bucket_name = TEST_APP_BUCKET_PREFIX + region
+        key_name = '{}{}'.format(KEY_PAIR_PREFIX, region)
+        app_bucket_name = '{}{}'.format(TEST_APP_BUCKET_PREFIX, region)
 
         if stack_type == 'vpc':
-            print 'Creating vpc stack in: ' + region
+            print 'Creating vpc stack in: {}'.format(region)
             stack_ids.append(create_vpc_stack(cfn_client, 'test-vpc-0', azs, 'dev'))
 
         if stack_type == 'vpc-bastion':
-            print 'Creating vpc + bastion stack in: ' + region
+            print 'Creating vpc bastion stack in: {}'.format(region)
             stack_ids.append(create_vpc_bastion_stack(cfn_client, 'test-vpc-bastion-0', azs, 'dev', key_name))
 
         if stack_type == 'vpc-bastion-eb-database':
-            print 'Creating eb stack in: ' + region
-            stack_ids.append(create_eb_stack(cfn_client, 'test-eb-0', azs, 'dev', key_name, app_bucket_name, TEST_PYTHON_APP_KEY, 'python', 'mysql'))
+            print 'Creating eb stack in: {}'.format(region)
+            stack_ids.append(create_eb_stack(cfn_client, 'test-eb-0', azs, 'dev', key_name, app_bucket_name, TEST_PYTHON_APP_KEY, 'python', 'mysql', False, False))
+
+        if stack_type == 'vpc-bastion-eb-database-alarm':
+            print 'Creating eb stack in: {}'.format(region)
+            stack_ids.append(create_eb_stack(cfn_client, 'test-eb-alarm-0', azs, 'dev', key_name, app_bucket_name, TEST_PYTHON_APP_KEY, 'python', 'postgres', True, False))
+
+        if stack_type == 'vpc-bastion-eb-database-enhanced-alarm':
+            print 'Creating eb stack with enhanced db monitoring in: {}'.format(region)
+            stack_ids.append(create_eb_stack(cfn_client, 'test-eb-enhanced-alarm-0', azs, 'dev', key_name, app_bucket_name, TEST_PYTHON_APP_KEY, 'python', 'mysql', True, True))
 
     time.sleep(5)
 
@@ -255,27 +276,33 @@ def test_stack(session, config, stack_type):
     print 'Deleting stacks'
     for stack in stacks:
         for stack_id in stack['stack_ids']:
-            print 'Deleting stack: ' + stack_id + ' - region: ' + stack['region']
+            print 'Deleting stack: {} - region: {}'.format(stack_id, stack['region'])
             stack['client'].delete_stack(StackName=stack_id)
 
     # Wait for the stacks to delete
     wait_for_stacks(stacks, False)
 
 def main():
-
+    """ Create the various stacks in all supported regions
+    """
     print 'Testing stacks'
 
     config = Config(connect_timeout=60, read_timeout=60)
-
     session = boto3.Session(profile_name=None if len(sys.argv) < 2 else sys.argv[1])
-
     print 'AWS session created'
 
     ensure_foundation(session, config)
 
-    test_stack(session, config, 'vpc')
-    test_stack(session, config, 'vpc-bastion')
-    test_stack(session, config, 'vpc-bastion-eb-database')
+    tests = [
+        'vpc',
+        'vpc-bastion',
+        'vpc-bastion-eb-database',
+        'vpc-bastion-eb-database-alarm',
+        'vpc-bastion-eb-database-enhanced-alarm',
+    ]
+
+    for test in tests:
+        test_stack(session, config, test)
 
 if __name__ == '__main__':
     main()

--- a/templates/aurora.cfn.yml
+++ b/templates/aurora.cfn.yml
@@ -3,10 +3,12 @@ AWSTemplateFormatVersion: 2010-09-09
 
 Description: Aurora
 
+# Create the Aurora MySQL or PostgreSQL database(s). Currently, this template only supports alarms for Aurora MySQL.
+
 Parameters:
 
   NetworkStackName:
-    Description: Name of an active CloudFormation stack that contains networking resources.
+    Description: Name of an active CloudFormation stack that contains networking resources
     Type: String
     MinLength: 1
     MaxLength: 255
@@ -19,7 +21,7 @@ Parameters:
     MinLength: 5
     MaxLength: 16
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
-    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters.
+    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters
 
   DatabasePassword:
     NoEcho: true
@@ -28,7 +30,7 @@ Parameters:
     MinLength: 6
     MaxLength: 41
     AllowedPattern: "[a-zA-Z0-9]*"
-    ConstraintDescription: Password must contain only alphanumeric characters.
+    ConstraintDescription: Password must contain only alphanumeric characters
 
   DatabaseName:
     Default: StartupDB
@@ -37,7 +39,7 @@ Parameters:
     MinLength: 1
     MaxLength: 30
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
-    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters.
+    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters
 
   DatabaseEngine:
     Default: aurora
@@ -74,13 +76,74 @@ Parameters:
       - db.r4.16xlarge
 
   EnvironmentName:
-    Description: Environment name - dev or prod.
+    Description: Environment name - dev or prod
     Type: String
     Default: dev
     AllowedValues:
       - dev
       - prod
-    ConstraintDescription: Specify either dev or prod.
+    ConstraintDescription: Specify either dev or prod
+
+  # The database alarm configuration, currently not supported for Aurora PostgreSQL
+  DatabaseAlarmMaxCpuPercent:
+    Description: Database CPU % max for alarm (currently, Aurora MySQL only)
+    Type: Number
+    Default: 80
+    MinValue: 1
+    MaxValue: 99
+    ConstraintDescription: Must be a percentage between 1-99%
+
+  DatabaseAlarmReadLatencyMaxSeconds:
+    Description: Read latency max for alarm (currently, Aurora MySQL only)
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  DatabaseAlarmWriteLatencyMaxSeconds:
+    Description: Write latency max for alarm (currently, Aurora MySQL only)
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  DatabaseAlarmEvaluationPeriods:
+    Description: The number of periods over which data is compared to the specified threshold (currently, Aurora MySQL only)
+    Type: Number
+    Default: 2
+    MinValue: 2
+
+  DatabaseAlarmEvaluationPeriodSeconds:
+    Description: The time over which the specified statistic is applied. Specify time in seconds, in multiples of 60. Enhanced monitoring must be enabled if less than 500 seconds (currently, Aurora MySQL only)
+    Type: Number
+    Default: 300
+    MinValue: 60
+    ConstraintDescription: Must be at least 60 seconds
+
+  EnhancedMonitoring:
+    Default: false
+    Type: String
+    Description: The optional flag for enhanced monitoring (additional charges apply - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html) (currently, Aurora MySQL only)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+  # Default is 200 MB
+  DatabaseAlarmSwapUsageInBytes:
+    Default: 209715200
+    Type: Number
+    Description: Number of swap usage bytes for alarm (if enabled - Aurora MySQL only)
+    MinValue: 1
+    ConstraintDescription: Enter a value of at least one byte
+
+  EnableAlarms:
+    Default: false
+    Type: String
+    Description: Set to true to enable (additional charges - https://aws.amazon.com/cloudwatch/pricing/ - currently, Aurora MySQL only)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
 
 Conditions:
 
@@ -88,7 +151,48 @@ Conditions:
 
   IsAuroraMySQL: !Equals [ !Ref DatabaseEngine, aurora ]
 
+  AlarmsEnabled: !And
+    - !Condition IsAuroraMySQL
+    - !Equals [ !Ref EnableAlarms, true ]
+
+  EnhancedMonitoringSupprtedAndEnabled: !And
+    - !Condition AlarmsEnabled
+    - !Equals [ !Ref EnhancedMonitoring, true ]
+
+
 Resources:
+
+  EnhancedMonitoringRole:
+    Type: AWS::IAM::Role
+    Condition: EnhancedMonitoringSupprtedAndEnabled
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: monitoring.rds.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole
+
+  DatabaseAlarmTopic:
+    Type: AWS::SNS::Topic
+    Condition: AlarmsEnabled
+    Properties:
+      DisplayName: Database Alarm Topic
+
+  DatabaseSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Database subnet group
+      SubnetIds:
+      - Fn::ImportValue: !Sub ${NetworkStackName}-PrivateSubnet1ID
+      - Fn::ImportValue: !Sub ${NetworkStackName}-PrivateSubnet2ID
+      Tags:
+      - Key: Name
+        Value: !Ref AWS::StackName
 
   AuroraCluster:
     Type: AWS::RDS::DBCluster
@@ -102,7 +206,7 @@ Resources:
       DBClusterParameterGroupName: !If [ IsAuroraMySQL,  default.aurora5.6, default.aurora-postgresql9.6 ]
       Port: !If [ IsAuroraMySQL,  3306, 5432 ]
       VpcSecurityGroupIds:
-        - Fn::ImportValue: !Sub "${NetworkStackName}-DatabaseGroupID"
+        - Fn::ImportValue: !Sub ${NetworkStackName}-DatabaseGroupID
     DependsOn: DatabaseSubnetGroup
 
   AuroraInstance0:
@@ -114,10 +218,12 @@ Resources:
       DBSubnetGroupName: !Ref DatabaseSubnetGroup
       StorageEncrypted: !Ref EncryptionAtRest
       DBParameterGroupName: !If [ IsAuroraMySQL,  default.aurora5.6, default.aurora-postgresql9.6 ]
+      MonitoringInterval: !If [ EnhancedMonitoringSupprtedAndEnabled, 60, 0 ]
+      MonitoringRoleArn: !If [ EnhancedMonitoringSupprtedAndEnabled, !GetAtt EnhancedMonitoringRole.Arn, !Ref "AWS::NoValue" ]
       CopyTagsToSnapshot: true
       Tags:
       - Key: Name
-        Value: !Ref "AWS::StackName"
+        Value: !Ref AWS::StackName
     DependsOn: AuroraCluster
 
   AuroraInstance1:
@@ -130,22 +236,129 @@ Resources:
       DBSubnetGroupName: !Ref DatabaseSubnetGroup
       StorageEncrypted: !Ref EncryptionAtRest
       DBParameterGroupName: !If [ IsAuroraMySQL,  default.aurora5.6, default.aurora-postgresql9.6 ]
+      MonitoringInterval: !If [ EnhancedMonitoringSupprtedAndEnabled, 60, 0 ]
+      MonitoringRoleArn: !If [ EnhancedMonitoringSupprtedAndEnabled, !GetAtt EnhancedMonitoringRole.Arn, !Ref "AWS::NoValue" ]
       CopyTagsToSnapshot: true
       Tags:
       - Key: Name
-        Value: !Ref "AWS::StackName"
+        Value: !Ref AWS::StackName
     DependsOn: AuroraCluster
 
-  DatabaseSubnetGroup:
-    Type: AWS::RDS::DBSubnetGroup
+  DatabaseCpuAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
-      DBSubnetGroupDescription: Database subnet group
-      SubnetIds:
-      - Fn::ImportValue: !Sub "${NetworkStackName}-PrivateSubnet1ID"
-      - Fn::ImportValue: !Sub "${NetworkStackName}-PrivateSubnet2ID"
-      Tags:
-      - Key: Name
-        Value: !Ref "AWS::StackName"
+      AlarmDescription: !Sub DB CPU utilization is over ${DatabaseAlarmMaxCpuPercent}% for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: CPUUtilization
+      Unit: Percent
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmMaxCpuPercent
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+  DatabaseSelectLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB read latency is over ${DatabaseAlarmReadLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: SelectLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmReadLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+  DatabaseInsertLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB insert latency is over ${DatabaseAlarmWriteLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: InsertLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+  DatabaseUpdateLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB update latency is over ${DatabaseAlarmWriteLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: UpdateLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
+  DatabaseDeleteLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB update latency is over ${DatabaseAlarmWriteLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: DeleteLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBClusterIdentifier
+          Value: !Ref AuroraCluster
+        - Name: Role
+          Value: WRITER
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: AuroraCluster
+
 
 Outputs:
 
@@ -159,23 +372,37 @@ Outputs:
     Description: Aurora Cluster ID
     Value: !Ref AuroraCluster
     Export:
-      Name: !Sub "${AWS::StackName}-AuroraClusterID"
+      Name: !Sub ${AWS::StackName}-AuroraClusterID
 
   AuroraDbURL:
     Description: Aurora Database URL
     Value: !GetAtt AuroraCluster.Endpoint.Address
     Export:
-      Name: !Sub "${AWS::StackName}-DatabaseURL"
+      Name: !Sub ${AWS::StackName}-DatabaseURL
 
   AuroraReadDbURL:
     Description: Aurora Database Read URL
     Value: !GetAtt AuroraCluster.ReadEndpoint.Address
     Export:
-      Name: !Sub "${AWS::StackName}-DatabaseReadURL"
+      Name: !Sub ${AWS::StackName}-DatabaseReadURL
 
   DbUser:
     Description: RDS Database admin account user
     Value: !Ref DatabaseUser
     Export:
-      Name: !Sub "${AWS::StackName}-DatabaseUser"
+      Name: !Sub ${AWS::StackName}-DatabaseUser
+
+  DatabaseAlarmTopicArn:
+    Description: Database Alarm Topic ARN
+    Condition: AlarmsEnabled
+    Value: !Ref DatabaseAlarmTopic
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseAlarmTopicArn
+
+  DatabaseAlarmTopicName:
+    Description: Database Alarm Topic Name
+    Condition: AlarmsEnabled
+    Value: !GetAtt DatabaseAlarmTopic.TopicName
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseAlarmTopicName
 

--- a/templates/db.cfn.yml
+++ b/templates/db.cfn.yml
@@ -7,7 +7,7 @@ Description: RDS
 Parameters:
 
   NetworkStackName:
-    Description: Name of an active CloudFormation stack that contains networking resources.
+    Description: Name of an active CloudFormation stack that contains networking resources
     Type: String
     MinLength: 1
     MaxLength: 255
@@ -20,7 +20,7 @@ Parameters:
     MinLength: 5
     MaxLength: 16
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
-    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters.
+    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters
 
   DatabasePassword:
     NoEcho: true
@@ -29,7 +29,7 @@ Parameters:
     MinLength: 6
     MaxLength: 41
     AllowedPattern: "[a-zA-Z0-9]*"
-    ConstraintDescription: Password must contain only alphanumeric characters.
+    ConstraintDescription: Password must contain only alphanumeric characters
 
   DatabaseName:
     Default: StartupDB
@@ -38,15 +38,30 @@ Parameters:
     MinLength: 1
     MaxLength: 30
     AllowedPattern: "[a-zA-Z][a-zA-Z0-9]*"
-    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters.
+    ConstraintDescription: Name must begin with a letter and contain only alphanumeric characters
 
   DatabaseSize:
     Default: 5
-    Type: String
+    Type: Number
     Description: Database storage size in gigabytes (GB)
-    MinLength: 1
-    AllowedPattern: "[5-9]|[1-9][0-9]+"
+    MinValue: 5
     ConstraintDescription: Enter a size of at least 5 GB
+
+  # Default is 500 MB
+  DatabaseAlarmMinFreeSpaceInBytes:
+    Default: 524288000
+    Type: Number
+    Description: Number of min free space bytes for alarm (if enabled)
+    MinValue: 1
+    ConstraintDescription: A value of one byte or more
+
+  # Default is 200 MB
+  DatabaseAlarmSwapUsageInBytes:
+    Default: 209715200
+    Type: Number
+    Description: Number of swap usage bytes for alarm (if enabled)
+    MinValue: 1
+    ConstraintDescription: A value of one byte or more
 
   DatabaseEngine:
     Default: postgres
@@ -93,26 +108,118 @@ Parameters:
       - db.r4.16xlarge
 
   EnvironmentName:
-    Description: Environment name, either dev or prod.
+    Description: Environment name, either dev or prod
     Type: String
     Default: dev
     AllowedValues:
       - dev
       - prod
-    ConstraintDescription: Specify either dev or prod.
+    ConstraintDescription: Specify either dev or prod
+
+  DatabaseAlarmMaxCpuPercent:
+    Description: Database CPU % max for alarm
+    Type: Number
+    Default: 80
+    MinValue: 1
+    MaxValue: 99
+    ConstraintDescription: Must be a percentage between 1-99%
+
+  DatabaseAlarmReadLatencyMaxSeconds:
+    Description: Read latency max for alarm
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  DatabaseAlarmWriteLatencyMaxSeconds:
+    Description: Write latency max for alarm
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  DatabaseAlarmEvaluationPeriods:
+    Description: The number of periods over which data is compared to the specified threshold
+    Type: Number
+    Default: 2
+    MinValue: 2
+
+  DatabaseAlarmEvaluationPeriodSeconds:
+    Description: The time over which the specified statistic is applied. Specify time in seconds, in multiples of 60. Enhanced monitoring must be enabled if less than 500 seconds
+    Type: Number
+    Default: 300
+    MinValue: 60
+    ConstraintDescription: Must be at least 60 seconds
+
+  EnhancedMonitoring:
+    Default: false
+    Type: String
+    Description: The optional flag for enhanced monitoring (additional charges apply - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.html)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+  EnableAlarms:
+    Default: false
+    Type: String
+    Description: Set to true to enable (additional charges - https://aws.amazon.com/cloudwatch/pricing/)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
 
 Conditions:
 
   IsProd: !Equals [ !Ref EnvironmentName, prod ]
 
+  AlarmsEnabled: !Equals [ !Ref EnableAlarms, true ]
+
+  EnhancedMonitoringSupprtedAndEnabled: !And
+    - !Condition AlarmsEnabled
+    - !Equals [ !Ref EnhancedMonitoring, true ]
+    - !Not [ !Equals [ !Ref DatabaseInstanceClass, "db.m1.small" ] ]
+
+
 Resources:
+
+  EnhancedMonitoringRole:
+    Type: AWS::IAM::Role
+    Condition: EnhancedMonitoringSupprtedAndEnabled
+    Properties:
+      Path: /
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: monitoring.rds.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole
+
+  DatabaseAlarmTopic:
+    Type: AWS::SNS::Topic
+    Condition: AlarmsEnabled
+    Properties:
+      DisplayName: Database Alarm Topic
+
+  DatabaseSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: Database subnet group
+      SubnetIds:
+      - Fn::ImportValue: !Sub ${NetworkStackName}-PrivateSubnet1ID
+      - Fn::ImportValue: !Sub ${NetworkStackName}-PrivateSubnet2ID
+      Tags:
+      - Key: Name
+        Value: !Ref AWS::StackName
 
   Database:
     Type: AWS::RDS::DBInstance
     Properties:
       DBSubnetGroupName: !Ref DatabaseSubnetGroup
       VPCSecurityGroups:
-        - Fn::ImportValue: !Sub "${NetworkStackName}-DatabaseGroupID"
+        - Fn::ImportValue: !Sub ${NetworkStackName}-DatabaseGroupID
       Engine: !Ref DatabaseEngine
       DBName: !Ref DatabaseName
       MasterUsername: !Ref DatabaseUser
@@ -122,22 +229,119 @@ Resources:
       StorageType: gp2
       MultiAZ: !If [ IsProd, true, false ]
       StorageEncrypted: !Ref EncryptionAtRest
+      MonitoringInterval: !If [ EnhancedMonitoringSupprtedAndEnabled, 60, 0 ]
+      MonitoringRoleArn: !If [ EnhancedMonitoringSupprtedAndEnabled, !GetAtt EnhancedMonitoringRole.Arn, !Ref "AWS::NoValue" ]
       CopyTagsToSnapshot: true
       Tags:
       - Key: Name
-        Value: !Ref "AWS::StackName"
+        Value: !Ref AWS::StackName
     DependsOn: DatabaseSubnetGroup
 
-  DatabaseSubnetGroup:
-    Type: AWS::RDS::DBSubnetGroup
+  DatabaseCpuAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
     Properties:
-      DBSubnetGroupDescription: Database subnet group
-      SubnetIds:
-      - Fn::ImportValue: !Sub "${NetworkStackName}-PrivateSubnet1ID"
-      - Fn::ImportValue: !Sub "${NetworkStackName}-PrivateSubnet2ID"
-      Tags:
-      - Key: Name
-        Value: !Ref "AWS::StackName"
+      AlarmDescription: !Sub DB CPU utilization is over ${DatabaseAlarmMaxCpuPercent}% for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: CPUUtilization
+      Unit: Percent
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmMaxCpuPercent
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !Ref Database
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: Database
+
+  DatabaseFreeStorageSpaceAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB free storage space is less than ${DatabaseAlarmMinFreeSpaceInBytes} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: FreeStorageSpace
+      Unit: Bytes
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmMinFreeSpaceInBytes
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !Ref Database
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: Database
+
+  DatabaseSwapUsageAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB swap usage is greater than than ${DatabaseAlarmSwapUsageInBytes} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: SwapUsage
+      Unit: Bytes
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmSwapUsageInBytes
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !Ref Database
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: Database
+
+  DatabaseReadLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB read latency is over ${DatabaseAlarmReadLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: ReadLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmReadLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !Ref Database
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: Database
+
+  DatabaseWriteLatencyAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Condition: AlarmsEnabled
+    Properties:
+      AlarmDescription: !Sub DB write latency is over ${DatabaseAlarmWriteLatencyMaxSeconds} for ${DatabaseAlarmEvaluationPeriods} period(s) of ${DatabaseAlarmEvaluationPeriodSeconds} seconds
+      TreatMissingData: notBreaching
+      Namespace: AWS/RDS
+      MetricName: WriteLatency
+      Unit: Seconds
+      Statistic: Average
+      EvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+      Period: !Ref DatabaseAlarmEvaluationPeriodSeconds
+      Threshold: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: DBInstanceIdentifier
+          Value: !Ref Database
+      AlarmActions:
+        - !Ref DatabaseAlarmTopic
+    DependsOn: Database
+
 
 Outputs:
 
@@ -151,23 +355,37 @@ Outputs:
     Description: RDS Database ID
     Value: !Ref Database
     Export:
-      Name: !Sub "${AWS::StackName}-DatabaseID"
+      Name: !Sub ${AWS::StackName}-DatabaseID
 
   RdsDbURL:
     Description: RDS Database URL
     Value: !GetAtt Database.Endpoint.Address
     Export:
-      Name: !Sub "${AWS::StackName}-DatabaseURL"
+      Name: !Sub ${AWS::StackName}-DatabaseURL
 
   DbUser:
     Description: RDS Database admin account user
     Value: !Ref DatabaseUser
     Export:
-      Name: !Sub "${AWS::StackName}-DatabaseUser"
+      Name: !Sub ${AWS::StackName}-DatabaseUser
 
   DbPassword:
     Description: RDS Database admin account password
     Value: !Ref DatabasePassword
     Export:
-      Name: !Sub "${AWS::StackName}-DatabasePassword"
+      Name: !Sub ${AWS::StackName}-DatabasePassword
+
+  DatabaseAlarmTopicArn:
+    Description: Database Alarm Topic ARN
+    Condition: AlarmsEnabled
+    Value: !Ref DatabaseAlarmTopic
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseAlarmTopicArn
+
+  DatabaseAlarmTopicName:
+    Description: Database Alarm Topic Name
+    Condition: AlarmsEnabled
+    Value: !GetAtt DatabaseAlarmTopic.TopicName
+    Export:
+      Name: !Sub ${AWS::StackName}-DatabaseAlarmTopicName
 

--- a/vpc-bastion-eb-rds.cfn.yml
+++ b/vpc-bastion-eb-rds.cfn.yml
@@ -9,7 +9,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v1
+    Default: awslabs-startup-kit-templates-deploy-v2
     Description: The template bucket for the CloudFormation templates
 
   EnvironmentName:
@@ -233,6 +233,74 @@ Parameters:
       - db.r4.8xlarge
       - db.r4.16xlarge
 
+  DatabaseEnableAlarms:
+    Default: false
+    Type: String
+    Description: Set to true to enable (additional charges - https://aws.amazon.com/cloudwatch/pricing/ - aurora, postgres, mariadb, mysql)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+  DatabaseEnhancedMonitoring:
+    Default: false
+    Type: String
+    Description: The optional flag for enhanced monitoring (additional charges apply - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.htm - aurora, postgres, mariadb, mysql)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+  DatabaseAlarmMaxCpuPercent:
+    Description: Database CPU % max for alarm (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 80
+    MinValue: 1
+    MaxValue: 99
+    ConstraintDescription: Must be a percentage between 1-99%
+
+  DatabaseAlarmReadLatencyMaxSeconds:
+    Description: Read latency max in seconds for alarm (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  DatabaseAlarmWriteLatencyMaxSeconds:
+    Description: Write latency max in seconds for alarm (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 1
+    MinValue: 1
+
+  DatabaseAlarmEvaluationPeriods:
+    Description: The number of periods over which data is compared to the specified threshold (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 2
+    MinValue: 2
+    ConstraintDescription: Must be at least one
+
+  DatabaseAlarmEvaluationPeriodSeconds:
+    Description: The time over which the specified statistic is applied. Specify time in seconds, in multiples of 60. Enhanced monitoring must be enabled if less than 500 second (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 300
+    MinValue: 60
+    ConstraintDescription: Must be at least 60 seconds
+
+  # Default is 500 MB
+  DatabaseAlarmMinFreeSpaceInBytes:
+    Default: 524288000
+    Type: Number
+    Description: Number of min free space bytes for alarm (postgres, mariadb, mysql)
+    MinValue: 1
+    ConstraintDescription: A value of one byte or more
+
+  # Default is 200 MB
+  DatabaseAlarmSwapUsageInBytes:
+    Default: 209715200
+    Type: Number
+    Description: Number of swap usage bytes for alarm (postgres, mariadb, mysql)
+    MinValue: 1
+    ConstraintDescription: A value of one byte or more
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -262,6 +330,15 @@ Metadata:
           - DatabaseName
           - DatabaseSize
           - EncryptionAtRest
+          - DatabaseEnableAlarms
+          - DatabaseEnhancedMonitoring
+          - DatabaseAlarmMaxCpuPercent
+          - DatabaseAlarmReadLatencyMaxSeconds
+          - DatabaseAlarmWriteLatencyMaxSeconds
+          - DatabaseAlarmEvaluationPeriods
+          - DatabaseAlarmEvaluationPeriodSeconds
+          - DatabaseAlarmMinFreeSpaceInBytes
+          - DatabaseAlarmSwapUsageInBytes
       - Label:
           default: Application Global
         Parameters:
@@ -335,7 +412,24 @@ Metadata:
         default: Min Instances
       AutoScalingMaxInstanceCount:
         default: Max Instances
-
+      DatabaseAlarmMaxCpuPercent:
+        default: Alarm Max CPU%
+      DatabaseAlarmReadLatencyMaxSeconds:
+        default: Alarm Max Read Latency
+      DatabaseAlarmWriteLatencyMaxSeconds:
+        default: Alarm Max Write Latency
+      DatabaseAlarmEvaluationPeriods:
+        default: Alarm Period(s)
+      DatabaseAlarmEvaluationPeriodSeconds:
+        default: Alarm Period Seconds
+      DatabaseEnhancedMonitoring:
+        default: Enhanced Monitoring
+      DatabaseAlarmMinFreeSpaceInBytes:
+        default: Min Free Space
+      DatabaseAlarmSwapUsageInBytes:
+        default: Max Swap Use
+      DatabaseEnableAlarms:
+        default: Enable Alarms
 
 Conditions:
 
@@ -384,6 +478,13 @@ Resources:
         DatabasePassword: !Ref DatabasePassword
         DatabaseName: !Ref DatabaseName
         EncryptionAtRest: !Ref EncryptionAtRest
+        EnableAlarms: !Ref DatabaseEnableAlarms
+        EnhancedMonitoring: !Ref DatabaseEnhancedMonitoring
+        DatabaseAlarmMaxCpuPercent: !Ref DatabaseAlarmMaxCpuPercent
+        DatabaseAlarmReadLatencyMaxSeconds: !Ref DatabaseAlarmReadLatencyMaxSeconds
+        DatabaseAlarmWriteLatencyMaxSeconds: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+        DatabaseAlarmEvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+        DatabaseAlarmEvaluationPeriodSeconds: !Ref DatabaseAlarmEvaluationPeriodSeconds
     DependsOn: VpcStack
 
   RdsStack:
@@ -401,6 +502,15 @@ Resources:
         DatabaseName: !Ref DatabaseName
         EncryptionAtRest: !Ref EncryptionAtRest
         DatabaseSize: !Ref DatabaseSize
+        EnableAlarms: !Ref DatabaseEnableAlarms
+        EnhancedMonitoring: !Ref DatabaseEnhancedMonitoring
+        DatabaseAlarmMaxCpuPercent: !Ref DatabaseAlarmMaxCpuPercent
+        DatabaseAlarmReadLatencyMaxSeconds: !Ref DatabaseAlarmReadLatencyMaxSeconds
+        DatabaseAlarmWriteLatencyMaxSeconds: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+        DatabaseAlarmEvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+        DatabaseAlarmEvaluationPeriodSeconds: !Ref DatabaseAlarmEvaluationPeriodSeconds
+        DatabaseAlarmMinFreeSpaceInBytes: !Ref DatabaseAlarmMinFreeSpaceInBytes
+        DatabaseAlarmSwapUsageInBytes: !Ref DatabaseAlarmSwapUsageInBytes
     DependsOn: VpcStack
 
   ElasticBeanstalkStack:

--- a/vpc-bastion-fargate-rds.cfn.yml
+++ b/vpc-bastion-fargate-rds.cfn.yml
@@ -2,14 +2,14 @@
 AWSTemplateFormatVersion: 2010-09-09
 
 
-Description: VPC + Bastion + Fargaate + Database
+Description: VPC + Bastion + Fargate + Database
 
 
 Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v1
+    Default: awslabs-startup-kit-templates-deploy-v2
     Description: The template bucket for the CloudFormation templates
 
   # vpc.cfn.yml parameters
@@ -290,6 +290,77 @@ Parameters:
       - db.r4.8xlarge
       - db.r4.16xlarge
 
+  DatabaseEnableAlarms:
+    Default: false
+    Type: String
+    Description: Set to true to enable (additional charges - https://aws.amazon.com/cloudwatch/pricing/ - aurora, postgres, mariadb, mysql)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+  DatabaseEnhancedMonitoring:
+    Default: false
+    Type: String
+    Description: The optional flag for enhanced monitoring (additional charges apply - https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Monitoring.OS.htm - aurora, postgres, mariadb, mysql)
+    ConstraintDescription: Only true or false are allowed
+    AllowedValues:
+      - true
+      - false
+
+  DatabaseAlarmMaxCpuPercent:
+    Description: Database CPU % max for alarm (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 80
+    MinValue: 1
+    MaxValue: 99
+    ConstraintDescription: Must be a percentage between 1-99%
+
+  DatabaseAlarmReadLatencyMaxSeconds:
+    Description: Read latency max in seconds for alarm (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 1
+    MinValue: 1
+    ConstraintDescription: Must at least one
+
+  DatabaseAlarmWriteLatencyMaxSeconds:
+    Description: Write latency max in seconds for alarm (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 1
+    MinValue: 1
+    ConstraintDescription: Must at least one
+
+  DatabaseAlarmEvaluationPeriods:
+    Description: The number of periods over which data is compared to the specified threshold (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 2
+    MinValue: 2
+    ConstraintDescription: Must be at least one
+
+  DatabaseAlarmEvaluationPeriodSeconds:
+    Description: The time over which the specified statistic is applied. Specify time in seconds, in multiples of 60. Enhanced monitoring must be enabled if less than 500 second (aurora, postgres, mariadb, mysql)
+    Type: Number
+    Default: 300
+    MinValue: 60
+    ConstraintDescription: Must be at least 60 seconds
+
+  # Default is 500 MB
+  DatabaseAlarmMinFreeSpaceInBytes:
+    Default: 524288000
+    Type: Number
+    Description: Number of min free space bytes for alarm (postgres, mariadb, mysql)
+    MinValue: 1
+    ConstraintDescription: A value of one byte or more
+
+  # Default is 200 MB
+  DatabaseAlarmSwapUsageInBytes:
+    Default: 209715200
+    Type: Number
+    Description: Number of swap usage bytes for alarm (postgres, mariadb, mysql)
+    MinValue: 1
+    ConstraintDescription: A value of one byte or more
+
+
 Metadata:
   AWS::CloudFormation::Interface:
     ParameterGroups:
@@ -319,6 +390,15 @@ Metadata:
           - DatabaseName
           - DatabaseSize
           - EncryptionAtRest
+          - DatabaseEnableAlarms
+          - DatabaseEnhancedMonitoring
+          - DatabaseAlarmMaxCpuPercent
+          - DatabaseAlarmReadLatencyMaxSeconds
+          - DatabaseAlarmWriteLatencyMaxSeconds
+          - DatabaseAlarmEvaluationPeriods
+          - DatabaseAlarmEvaluationPeriodSeconds
+          - DatabaseAlarmMinFreeSpaceInBytes
+          - DatabaseAlarmSwapUsageInBytes
       - Label:
           default: Application Global
         Parameters:
@@ -431,6 +511,25 @@ Metadata:
         default: Encryption at Rest
       DatabaseInstanceClass:
         default: Instance Type
+      DatabaseAlarmMaxCpuPercent:
+        default: Alarm Max CPU%
+      DatabaseAlarmReadLatencyMaxSeconds:
+        default: Alarm Max Read Latency
+      DatabaseAlarmWriteLatencyMaxSeconds:
+        default: Alarm Max Write Latency
+      DatabaseAlarmEvaluationPeriods:
+        default: Alarm Period(s)
+      DatabaseAlarmEvaluationPeriodSeconds:
+        default: Alarm Period Seconds
+      DatabaseEnhancedMonitoring:
+        default: Enhanced Monitoring
+      DatabaseAlarmMinFreeSpaceInBytes:
+        default: Min Free Space
+      DatabaseAlarmSwapUsageInBytes:
+        default: Max Swap Use
+      DatabaseEnableAlarms:
+        default: Enable Alarms
+
 
 Conditions:
 
@@ -479,6 +578,13 @@ Resources:
         DatabasePassword: !Ref DatabasePassword
         DatabaseName: !Ref DatabaseName
         EncryptionAtRest: !Ref EncryptionAtRest
+        EnableAlarms: !Ref DatabaseEnableAlarms
+        EnhancedMonitoring: !Ref DatabaseEnhancedMonitoring
+        DatabaseAlarmMaxCpuPercent: !Ref DatabaseAlarmMaxCpuPercent
+        DatabaseAlarmReadLatencyMaxSeconds: !Ref DatabaseAlarmReadLatencyMaxSeconds
+        DatabaseAlarmWriteLatencyMaxSeconds: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+        DatabaseAlarmEvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+        DatabaseAlarmEvaluationPeriodSeconds: !Ref DatabaseAlarmEvaluationPeriodSeconds
     DependsOn: VpcStack
 
   RdsStack:
@@ -496,6 +602,15 @@ Resources:
         DatabaseName: !Ref DatabaseName
         EncryptionAtRest: !Ref EncryptionAtRest
         DatabaseSize: !Ref DatabaseSize
+        EnableAlarms: !Ref DatabaseEnableAlarms
+        EnhancedMonitoring: !Ref DatabaseEnhancedMonitoring
+        DatabaseAlarmMaxCpuPercent: !Ref DatabaseAlarmMaxCpuPercent
+        DatabaseAlarmReadLatencyMaxSeconds: !Ref DatabaseAlarmReadLatencyMaxSeconds
+        DatabaseAlarmWriteLatencyMaxSeconds: !Ref DatabaseAlarmWriteLatencyMaxSeconds
+        DatabaseAlarmEvaluationPeriods: !Ref DatabaseAlarmEvaluationPeriods
+        DatabaseAlarmEvaluationPeriodSeconds: !Ref DatabaseAlarmEvaluationPeriodSeconds
+        DatabaseAlarmMinFreeSpaceInBytes: !Ref DatabaseAlarmMinFreeSpaceInBytes
+        DatabaseAlarmSwapUsageInBytes: !Ref DatabaseAlarmSwapUsageInBytes
     DependsOn: VpcStack
 
   FargateStack:

--- a/vpc-bastion-fargate.cfn.yml
+++ b/vpc-bastion-fargate.cfn.yml
@@ -9,7 +9,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v1
+    Default: awslabs-startup-kit-templates-deploy-v2
     Description: The template bucket for the CloudFormation templates
 
   # vpc.cfn.yml parameters

--- a/vpc-bastion.cfn.yml
+++ b/vpc-bastion.cfn.yml
@@ -9,7 +9,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v1
+    Default: awslabs-startup-kit-templates-deploy-v2
     Description: The template bucket for the CloudFormation templates
 
   AvailabilityZone1:

--- a/vpc.cfn.yml
+++ b/vpc.cfn.yml
@@ -8,7 +8,7 @@ Parameters:
 
   TemplateBucket:
     Type: String
-    Default: awslabs-startup-kit-templates-deploy-v1
+    Default: awslabs-startup-kit-templates-deploy-v2
     Description: The template bucket for the CloudFormation templates
 
   AvailabilityZone1:


### PR DESCRIPTION
This PR adds optional support for CloudWatch Alarms for the standard RDS engines as well as Aurora MySQL.

The new template bucket is: awslabs-startup-kit-templates-deploy-v2

Alarms publish to a new SNS topic.

Users can choose between standard (default) and enhanced RDS monitoring.

The launch stacks have been updated.

The test harness was updated to validate the extra conditions.

Standard RDS engines have the following alarms (if enabled):
- CPU
- Low free storage space
- Swap usage
- Read latency
- Write latency

Aurora MySQL has alarms for (if enabled):
- CPU
- Select latency
- Insert latency
- Update latency
- Delete latency

Aurora PostgreSQL is not currently supported.