### PR TITLE
Remove duplicate fields

### DIFF
--- a/vpc-bastion.cfn.yml
+++ b/vpc-bastion.cfn.yml
@@ -118,8 +118,6 @@ Metadata:
         default: Log Retention
       MFA:
         default: Multi-Factor
-      SSHFrom:
-        default: SSH Whitelist
 
 
 Conditions:

--- a/vpc-elasticache.cfn.yml
+++ b/vpc-elasticache.cfn.yml
@@ -138,8 +138,6 @@ Metadata:
         default: CloudFormation Bucket
       EnvironmentName:
         default: Environment
-      SSHFrom:
-        default: SSH Whitelist
 
 Conditions:
 


### PR DESCRIPTION
Having duplicate fields causes the JSON validator in the AWS
CloudFormation Visualization console to fail with this error:

```
 6/18/2019, 12:09:20 AM - Cannot convert the template because of an
 error:: duplicated mapping key at line 129, column 1: Conditions: ^
```