### PR TITLE
Fix testing condition IsRedis in template elasticache.cfn.yml

### DIFF
--- a/templates/elasticache.cfn.yml
+++ b/templates/elasticache.cfn.yml
@@ -78,7 +78,7 @@ Parameters:
 
 Conditions:
 
-  IsRedis: !Equals [ !Ref CacheEngine, redis]
+  IsRedis: !Equals [ !Ref CacheEngine, 'redis']
 
 Resources:
 
@@ -89,13 +89,11 @@ Resources:
       VpcId:
         Fn::ImportValue: !Sub ${NetworkStackName}-VpcID
       SecurityGroupIngress:
-        -
-          IpProtocol: tcp
+        - IpProtocol: tcp
           FromPort: !If [ IsRedis, 6379, 11211]
           ToPort: !If [ IsRedis, 6379, 11211]
       Tags:
-        -
-          Key: Name
+        - Key: Name
           Value: !Sub "${AWS::StackName}-ElastiCacheSecurityGroup"
 
   SubnetGroup:


### PR DESCRIPTION
Fix IsRedis testing condition so that inbound rule are created, for the resource named "SecurityGroup" in elasticache.cfn.yml template.
